### PR TITLE
Add new domain models and types

### DIFF
--- a/components/WithInstantBandit.tsx
+++ b/components/WithInstantBandit.tsx
@@ -9,7 +9,7 @@ import {
   sendExposure,
   setSessionVariant,
 } from "../lib/lib"
-import { InstantBanditOptions } from "../lib/types"
+import { InstantBanditProps } from "../lib/types"
 
 type WithInstantBanditProps = {
   variant: string // designed to be overridden by author
@@ -41,7 +41,7 @@ export function WithInstantBandit<
   experimentId: string,
   variants: T["variant"][],
   defaultVariant: T["variant"]
-): React.FC<WithoutVariant<T> & InstantBanditOptions> {
+): React.FC<WithoutVariant<T> & InstantBanditProps> {
   // Return the wrapped component with variant set
   // console.time("wrap")
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,29 @@
+export const DEFAULT_NAME = "@default"
+export const DEFAULT_SITE_NAME = DEFAULT_NAME
+export const DEFAULT_EXPERIMENT_ID = DEFAULT_NAME
+export const DEFAULT_EXPERIMENT_NAME = DEFAULT_NAME
+export const DEFAULT_VARIANT_NAME = DEFAULT_NAME
+export const DEFAULT_ORIGIN = "localhost"
+export const DEFAULT_BASE_URL = "http://localhost:3000"
+export const DEFAULT_SITE_PATH = "api/site"
+export const DEFAULT_METRICS_PATH = "api/metrics"
+
+// Any env vars prefixed with this are exposed to the browser
+// See: https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser
+export const NEXTJS_PUBLIC_PREFIX = "NEXT_PUBLIC_"
+
+export const VARNAME_BASE_URL = "DEFAULT_BASE_URL"
+export const VARNAME_BASE_URL_PUBLIC = NEXTJS_PUBLIC_PREFIX + VARNAME_BASE_URL
+export const VARNAME_SITE_PATH = "DEFAULT_SITE_PATH"
+export const VARNAME_METRICS_PATH = "DEFAULT_METRICS_PATH"
+
+export const HEADER_SESSION_ID = "X-IB-Session"
+
+
+/**
+ * Metrics tracked by Instant Bandit by default
+ */
+export enum DefaultMetrics {
+  EXPOSURES = "exposures",
+  CONVERSIONS = "conversions",
+}

--- a/lib/defaults.ts
+++ b/lib/defaults.ts
@@ -1,0 +1,46 @@
+import * as constants from "./constants"
+import { AlgorithmResults } from "./types"
+import { SiteMeta } from "./models"
+import { deepFreeze } from "./utils"
+
+
+/**
+ * 
+ * This file defines the built-in default model and is used as a fallback,
+ * as well as the template for new sites.
+ * 
+ * It represents the invariant, baseline version of a new or existing site.
+ * 
+ */
+const {
+  DEFAULT_ORIGIN,
+  DEFAULT_SITE_NAME,
+  DEFAULT_EXPERIMENT_ID,
+  DEFAULT_EXPERIMENT_NAME,
+  DEFAULT_VARIANT_NAME,
+} = constants
+
+export const DEFAULT_SITE = deepFreeze<SiteMeta>({
+  name: DEFAULT_SITE_NAME,
+  origin: DEFAULT_ORIGIN,
+  experiments: [{
+    id: DEFAULT_EXPERIMENT_ID,
+    name: DEFAULT_EXPERIMENT_NAME,
+    metrics: {},
+    variants: [{
+      name: DEFAULT_VARIANT_NAME,
+      prob: 1,
+      metrics: {},
+      props: {},
+    }],
+  }],
+})
+
+export const DEFAULT_EXPERIMENT = DEFAULT_SITE.experiments[0]
+export const DEFAULT_VARIANT = DEFAULT_EXPERIMENT.variants[0]
+export const DEFAULT_METRICS = DEFAULT_VARIANT.metrics
+export const DEFAULT_ALGO_RESULTS: AlgorithmResults = deepFreeze({
+  winner: DEFAULT_VARIANT,
+  pValue: 0,
+  metrics: {},
+})

--- a/lib/lib.ts
+++ b/lib/lib.ts
@@ -1,4 +1,5 @@
 import fetch from "node-fetch"
+
 import {
   ConversionOptions,
   Counts,
@@ -6,9 +7,11 @@ import {
   ProbabilityDistribution,
   Variant,
 } from "./types"
+import { getBaseUrl } from "./utils"
 
-// TODO: make env var
-export const baseUrl = "http://localhost:3000/api"
+
+const baseUrl = getBaseUrl() + "/api"
+
 
 /**
  * Fetches ProbabilityDistribution from the server for an experiment with
@@ -17,7 +20,7 @@ export const baseUrl = "http://localhost:3000/api"
 export async function fetchProbabilities(
   experimentId: string,
   defaultVariant: Variant,
-  timeout = 250 // NOTE: 100ms is needed to pass unit tests
+  timeout = 1000 // NOTE: 100ms is needed to pass unit tests
 ): Promise<ProbabilityDistribution | null> {
   const controller = new AbortController()
   try {

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,0 +1,92 @@
+/**
+ * Domain Models
+ * 
+ * These models formalize a language that Instant Bandit clients and servers can speak.
+ * Types suffixed in `Meta` represent additional server-side info.
+ * 
+ */
+
+
+/**
+ * Represents configuration for a particular site/app and the variants to test
+ */
+export interface Site {
+  name: string
+  select?: string | null
+  session?: string | null
+  experiments: Experiment[]
+}
+
+/**
+ * Full metadata for a `Site`, including the set of defined experiments
+ */
+export interface SiteMeta extends Site {
+  origin: string
+  experiments: ExperimentMeta[]
+}
+
+/**
+ * A named grouping of variants to test for some amount of time or other criteria
+ */
+export interface Experiment {
+  id: string
+  inactive?: boolean
+  variants: Variant[]
+}
+
+/**
+ * A named set of variants with metadata around lifecycle such as start/end dates
+ */
+export interface ExperimentMeta extends Experiment {
+  name: string
+  desc?: string
+  metrics: MetricsBucket
+  variants: VariantMeta[]
+}
+
+/**
+ * A particular variation of a site/app and the probability that the variant will be presented
+ */
+export interface Variant {
+  name: string
+  prob?: number
+  props?: PropsBucket
+}
+
+/**
+ * Metadata required about a particular variant
+ */
+export interface VariantMeta extends Variant {
+  prob: number
+  metrics: MetricsBucket
+}
+
+/**
+ * An aggregated bucket of metrics for a particular variant or site
+ */
+export interface MetricsBucket {
+  [metric: string]: number
+}
+
+/**
+ * Arbitrary properties that variants can define
+ */
+export interface PropsBucket {
+  [name: string]: string | number | boolean
+}
+
+/**
+ * An individual metric sample to report to a metrics sink such as a Redis backend.
+ * Samples are associated with experiments and variants and aggregated into the
+ * metrics buckets on the server side.
+ */
+export interface MetricsSample {
+  ts: number
+  site: string
+  session: string
+  origin: string
+  experiment: string
+  variant: string
+  name: string
+  value: number
+}

--- a/lib/sites.ts
+++ b/lib/sites.ts
@@ -1,0 +1,22 @@
+import * as constants from "./constants"
+import { Site } from "./models"
+
+export const DEMO_SITE: Site = {
+  name: constants.DEFAULT_SITE_NAME,
+  experiments: [
+    {
+      id: constants.DEFAULT_EXPERIMENT_ID,
+      variants: [
+        {
+          name: "A",
+        },
+        {
+          name: "B",
+        },
+        {
+          name: "C",
+        },
+      ],
+    }
+  ],
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,16 +1,100 @@
-export type Variant = string
-export type Probability = number
+import { Experiment, MetricsBucket, MetricsSample, Site, Variant as VariantModel } from "./models"
 
-/**
- * Map of probabilities that should add up to 1.0.
- */
-export type ProbabilityDistribution = Record<Variant, Probability>
 
-export type InstantBanditOptions = {
-  probabilities?: ProbabilityDistribution | null // for overriding locally
-  preserveSession?: boolean // for overriding locally
+export interface InstantBanditProps {
+  preserveSession?: boolean
+  probabilities?: ProbabilityDistribution | null
+  select?: string
+  site?: Site
+  debug?: boolean
+  onReady?: (state: InstantBanditState) => void
+  onError?: (err: Error | null, state: InstantBanditState | null) => void
 }
 
+export interface InstantBanditState extends Scope {
+  state: LoadState
+  error: Error | null
+  site: Site | null
+  siteName: string
+  experiment: string
+  variant: VariantModel | null
+}
+
+export interface Scope {
+  siteName: string
+  variant: VariantModel | null
+}
+
+export interface AlgorithmImpl<TAlgoArgs = unknown> {
+  select<TAlgoArgs>(args: TAlgoArgs & SelectionArgs): Promise<AlgorithmResults>
+}
+
+export interface SelectionArgs<TAlgoParams = unknown> {
+  site: Site
+  algo: Algorithm | string
+  params: TAlgoParams | null
+  variants: readonly VariantModel[]
+}
+
+export type Selection = { experiment: Experiment, variant: VariantModel }
+
+export enum LoadState {
+  PRELOAD = "pre",
+  WAIT = "wait-for-data",
+  SELECTING = "selecting",
+  READY = "ready",
+}
+
+/**
+ * Algorithms to use when selecting a variant.
+ */
+export enum Algorithm {
+  RANDOM = "random",
+  MAB_EPSILON_GREEDY = "mab-epsilon-greedy",
+}
+
+export type AlgorithmFactory = () => AlgorithmImpl
+export type Algorithms = Record<string, AlgorithmFactory>
+export interface AlgorithmResults {
+  pValue: number
+  metrics: MetricsBucket
+  winner: VariantModel
+}
+
+export interface SessionProvider {
+  getOrCreateSession(site: string, props?: Partial<SessionDescriptor>): Promise<SessionDescriptor>
+  persistVariant(site: string, experiment: string, variant: string)
+  hasSeen(site: string, experiment: string, variant: string)
+}
+
+export interface MetricsProvider {
+  push(metric: MetricsSample): void
+  flush(): Promise<void>
+}
+
+export type ProviderFactory<T> = () => T
+export type Providers = {
+  session: SessionProvider
+  metrics: MetricsProvider
+}
+
+/**
+ * Describes a user session, scoped per origin and site.
+ * Includes the selected variant for the current site.
+ */
+export interface SessionDescriptor {
+  origin: string
+  site: string | null
+  variants: { [experiment: string]: string[] }
+
+  // Session and user IDs
+  sid?: string
+  uid?: string
+}
+
+export type Variant = string
+export type Probability = number
+export type ProbabilityDistribution = Record<Variant, Probability>
 export type ConversionOptions = {
   experimentIds?: string[] // whitelist of experiments to associate with the conversion
   value?: number // optional value of the conversion
@@ -26,5 +110,8 @@ export type ProbabilitiesResponse = {
   pValue: PValue | null
 }
 
-// p-value of difference in counts between variants
+// p-value of difference between variants
 export type PValue = number
+
+// Node and DOM typings for `setTimeout` / `setInterval` differ
+export type TimerLike = any

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,64 @@
+import { useEffect, useLayoutEffect } from "react"
+
+import * as constants from "./constants"
+
+
+/**
+ * Freezes an entire object tree.
+ * @param obj 
+ * @returns 
+ */
+export function deepFreeze<T extends object>(obj: T, seen = new WeakMap()) {
+  if (!exists(obj)) return obj
+
+  seen.set(obj, true)
+
+  Object.getOwnPropertyNames(obj)
+    .filter(prop => obj[prop] && typeof obj[prop] === "object")
+    .filter(prop => !seen.has(obj[prop]))
+    .forEach(prop => deepFreeze(obj[prop]))
+
+  return Object.freeze(obj)
+}
+
+/**
+ * Returns `true` if something is non-null and non-undefined
+ * @param thing 
+ * @returns 
+ */
+export function exists(thing: unknown) {
+  return (thing !== undefined && thing !== null)
+}
+
+/**
+ * Pulls an environment variable either from a server environment
+ * or from Next.js' public env vars exposed to the client.
+ * @param name 
+ * @returns 
+ */
+export function env(name: string): string | undefined {
+  if (typeof process === "undefined") {
+    return undefined
+  } else if (isBrowserEnvironment) {
+    return process.env[constants.NEXTJS_PUBLIC_PREFIX + name]
+  } else {
+    return process.env[name]
+  }
+}
+
+/**
+ * Gets the base URL, observing environment variables if in a Node environment
+ * @returns 
+ */
+export function getBaseUrl() {
+  return env(constants.VARNAME_BASE_URL) ?? constants.DEFAULT_BASE_URL
+}
+
+export const isBrowserEnvironment =
+  typeof window !== "undefined"
+
+export const useIsomorphicLayoutEffect =
+  isBrowserEnvironment ? useLayoutEffect : useEffect
+
+export const flushPromises = async () => new Promise((resolve) => { scheduler(resolve) })
+const scheduler = typeof setImmediate === "function" ? setImmediate : setTimeout

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -8,17 +8,17 @@ import * as constants from "./constants"
  * @param obj 
  * @returns 
  */
-export function deepFreeze<T extends object>(obj: T, seen = new WeakMap()) {
+export function deepFreeze<T extends object>(obj: T, seen = new WeakMap<T, any>()) {
   if (!exists(obj)) return obj
 
   seen.set(obj, true)
 
   Object.getOwnPropertyNames(obj)
-    .filter(prop => obj[prop] && typeof obj[prop] === "object")
     .filter(prop => !seen.has(obj[prop]))
-    .forEach(prop => deepFreeze(obj[prop]))
+    .filter(prop => obj[prop] && typeof obj[prop] === "object")
+    .forEach(prop => deepFreeze(obj[prop], seen))
 
-  return Object.freeze(obj)
+  return Object.freeze<T>(obj)
 }
 
 /**

--- a/pages/api/site.ts
+++ b/pages/api/site.ts
@@ -1,0 +1,10 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import { DEMO_SITE } from "../../lib/sites"
+
+
+// This endpoint will serve sites hydrated with probabilities from the backend data source.
+// It will also hydrate site variants with their probalities, and perform variant selection.
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const site = DEMO_SITE
+  res.status(200).json(site)
+}

--- a/pages/api/site.ts
+++ b/pages/api/site.ts
@@ -2,8 +2,8 @@ import { NextApiRequest, NextApiResponse } from "next"
 import { DEMO_SITE } from "../../lib/sites"
 
 
-// This endpoint will serve sites hydrated with probabilities from the backend data source.
-// It will also hydrate site variants with their probalities, and perform variant selection.
+// This endpoint will serve sites associated with one or more particular domains.
+// These site models will be hydrated with their probabilities inline with each "variant".
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const site = DEMO_SITE
   res.status(200).json(site)

--- a/testing/sites.ts
+++ b/testing/sites.ts
@@ -1,0 +1,38 @@
+import {
+  Variant,
+  VariantMeta,
+  Site,
+  SiteMeta
+} from "../lib/models"
+import { DEFAULT_ORIGIN } from "../lib/constants"
+
+
+export const TEST_SITE_A: Site = {
+  name: "test-site-a",
+  experiments: [],
+}
+
+export const TEST_SITE_B: Site = {
+  name: "test-site-b",
+  experiments: [],
+}
+
+export const TEST_VARIANT_A: Variant = {
+  name: "A",
+  prob: 0.5,
+}
+
+export const TEST_VARIANT_B: Variant = {
+  name: "B",
+  prob: 0.5,
+}
+
+export const TEST_SITE_AB: Site = {
+  name: "test-site-ab",
+  experiments: [
+    {
+      id: "some-guid",
+      variants: [TEST_VARIANT_A, TEST_VARIANT_B],
+    },
+  ],
+}

--- a/testing/test-utils.ts
+++ b/testing/test-utils.ts
@@ -1,0 +1,32 @@
+import { act, render, RenderResult } from "@testing-library/react"
+import { TEST_SITE_AB } from "./sites"
+
+
+/**
+ * Renders a component, taking async effects into account via `act`
+ * @param tree 
+ * @returns 
+ */
+export async function renderTest(tree: React.ReactElement): Promise<RenderResult> {
+  let rendered
+  await act(async () => { rendered = await render(tree) })
+  return rendered
+}
+
+
+export function siteLoadResponse(site = TEST_SITE_AB) {
+  return (req: Request) => Promise.resolve(JSON.stringify(site))
+}
+
+export function siteErrorResponse(errorText = "MOCK-ERROR") {
+  return (req: Request) => Promise.reject(new Error(errorText))
+}
+
+export function disableJestLogging() {
+  jestConsole = global.console
+  global.console = require("console")
+}
+export function resetJestLogging() {
+  global.console = jestConsole
+}
+let jestConsole = global.console

--- a/testing/tests/api/_api.test.ts
+++ b/testing/tests/api/_api.test.ts
@@ -1,13 +1,16 @@
 // NOTE: next server should be running. Try `yarn run dev`.
-
 import fetch from "node-fetch"
 import { setConversions, setExposures } from "../../../lib/db"
-import { baseUrl, postData } from "../../../lib/lib"
+import { postData } from "../../../lib/lib"
+import { getBaseUrl } from "../../../lib/utils"
+
+const baseUrl = getBaseUrl()
+const apiUrl = baseUrl + "/api/"
 
 describe("API", () => {
   describe("_hello", () => {
     test("returns", async () => {
-      const res = await fetch(`${baseUrl}/_hello`)
+      const res = await fetch(`${apiUrl}/_hello`)
       const data = await res.json()
       expect(data).toEqual({ name: "Hello World" })
     })
@@ -15,7 +18,7 @@ describe("API", () => {
 
   describe("_database", () => {
     test("returns", async () => {
-      const res = await fetch(`${baseUrl}/_database`)
+      const res = await fetch(`${apiUrl}/_database`)
       const data = await res.json()
       expect(data).toEqual({ _testKey: "true" })
     })
@@ -23,7 +26,7 @@ describe("API", () => {
 
   describe("probabilities", () => {
     test("returns null when no experimentId", async () => {
-      const res = await fetch(`${baseUrl}/probabilities`)
+      const res = await fetch(`${apiUrl}/probabilities`)
       const data = await res.json()
       expect(data).toEqual({
         name: "probabilities",
@@ -34,7 +37,7 @@ describe("API", () => {
 
     test("returns null when new experimentId", async () => {
       const res = await fetch(
-        `${baseUrl}/probabilities?experimentId=${Math.random()}`
+        `${apiUrl}/probabilities?experimentId=${Math.random()}`
       )
       const data = await res.json()
       expect(data).toEqual({
@@ -47,7 +50,7 @@ describe("API", () => {
     test("returns probabilities from stored values", async () => {
       const id = "_testProbabilities"
       await setExposures(id, { A: 100 })
-      const res = await fetch(`${baseUrl}/probabilities?experimentId=${id}`)
+      const res = await fetch(`${apiUrl}/probabilities?experimentId=${id}`)
       const data = await res.json()
       expect(data.probabilities).toHaveProperty("A")
     })
@@ -58,7 +61,7 @@ describe("API", () => {
       const id = "_testExposures"
       const variant = "A"
       await setExposures(id, { [variant]: 100 })
-      const res = await postData(`${baseUrl}/exposures`, {
+      const res = await postData(`${apiUrl}/exposures`, {
         experimentId: id,
         variant,
         variants: [variant],
@@ -72,7 +75,7 @@ describe("API", () => {
       const variantA = "A"
       const variantB = "B"
       await setExposures(id, { [variantA]: 100 })
-      const res = await postData(`${baseUrl}/exposures`, {
+      const res = await postData(`${apiUrl}/exposures`, {
         experimentId: id,
         variant: variantB,
         variants: [variantB], // key line
@@ -82,11 +85,11 @@ describe("API", () => {
     })
 
     test("returns bad request when bad data", async () => {
-      const res = await postData(`${baseUrl}/exposures`, {})
+      const res = await postData(`${apiUrl}/exposures`, {})
       try {
         await res.json()
         expect(true).toBeFalsy()
-      } catch (error) {}
+      } catch (error) { }
       expect(res.status).toEqual(400)
     })
   })
@@ -96,7 +99,7 @@ describe("API", () => {
       const id = "_testConversions"
       await setExposures(id, { A: 100 })
       await setConversions(id, { A: 10 })
-      const res = await postData(`${baseUrl}/conversions`, {
+      const res = await postData(`${apiUrl}/conversions`, {
         experiments: { [id]: "A" },
       })
       const data = await res.json()
@@ -111,7 +114,7 @@ describe("API", () => {
     test("does not set a conversion when no exposures", async () => {
       const id = "_testConversions"
       await setExposures(id, { A: 0 })
-      const res = await postData(`${baseUrl}/conversions`, {
+      const res = await postData(`${apiUrl}/conversions`, {
         experiments: { [id]: "A" },
       })
       const data = await res.json()
@@ -124,11 +127,11 @@ describe("API", () => {
     })
 
     test("returns bad request when bad data", async () => {
-      const res = await postData(`${baseUrl}/conversions`, {})
+      const res = await postData(`${apiUrl}/conversions`, {})
       try {
         await res.json()
         expect(true).toBeFalsy()
-      } catch (error) {}
+      } catch (error) { }
       expect(res.status).toEqual(400)
     })
   })

--- a/testing/tests/api/_api.test.ts
+++ b/testing/tests/api/_api.test.ts
@@ -1,8 +1,8 @@
 // NOTE: next server should be running. Try `yarn run dev`.
 
 import fetch from "node-fetch"
-import { setConversions, setExposures } from "../../lib/db"
-import { baseUrl, postData } from "../../lib/lib"
+import { setConversions, setExposures } from "../../../lib/db"
+import { baseUrl, postData } from "../../../lib/lib"
 
 describe("API", () => {
   describe("_hello", () => {

--- a/testing/tests/api/_api.test.ts
+++ b/testing/tests/api/_api.test.ts
@@ -5,7 +5,7 @@ import { postData } from "../../../lib/lib"
 import { getBaseUrl } from "../../../lib/utils"
 
 const baseUrl = getBaseUrl()
-const apiUrl = baseUrl + "/api/"
+const apiUrl = baseUrl + "/api"
 
 describe("API", () => {
   describe("_hello", () => {

--- a/testing/tests/bandit.test.ts
+++ b/testing/tests/bandit.test.ts
@@ -1,4 +1,4 @@
-import { bandit, conversionRates, maxKey, otherProbabilities } from "./bandit"
+import { bandit, conversionRates, maxKey, otherProbabilities } from "../../lib/bandit"
 
 describe("maxKey", () => {
   it("should return the max variant", () => {

--- a/testing/tests/components/DemoComponent.test.tsx
+++ b/testing/tests/components/DemoComponent.test.tsx
@@ -3,9 +3,9 @@
  */
 
 import { render, waitFor } from "@testing-library/react"
-import { getSessionVariant, setSessionVariant } from "../lib/lib"
-import * as lib from "../lib/lib"
-import { DemoComponent, demoExperimentId } from "./DemoComponent"
+import { getSessionVariant, setSessionVariant } from "../../../lib/lib"
+import * as lib from "../../../lib/lib"
+import { DemoComponent, demoExperimentId } from "../../../components/DemoComponent"
 
 beforeEach(() => {
   sessionStorage.clear()

--- a/testing/tests/lib.test.ts
+++ b/testing/tests/lib.test.ts
@@ -1,11 +1,11 @@
-import { demoExperimentId } from "../components/DemoComponent"
+import { demoExperimentId } from "../../components/DemoComponent"
 import {
   fetchProbabilities,
   selectVariant,
   setSessionVariant,
   getSessionVariant,
   incrementCounts,
-} from "./lib"
+} from "../../lib/lib"
 
 beforeEach(() => {
   sessionStorage.clear()

--- a/testing/tests/pvalue.test.ts
+++ b/testing/tests/pvalue.test.ts
@@ -1,4 +1,4 @@
-import { getPValue } from "./pvalue"
+import { getPValue } from "../../lib/pvalue"
 
 describe("getPValue", () => {
   test("returns correct values", () => {

--- a/testing/tests/utils.test.ts
+++ b/testing/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { exists } from "../../lib/utils"
+import { deepFreeze, exists } from "../../lib/utils"
 
 
 describe("utils", () => {
@@ -8,5 +8,25 @@ describe("utils", () => {
     it("returns true for an empty string", () => expect(exists("")).toStrictEqual(true))
     it("returns true for 0", () => expect(exists(0)).toStrictEqual(true))
     it("returns true for NaN", async () => expect(exists(0)).toStrictEqual(true))
+  })
+
+  describe("deepFreeze", () => {
+    let obj = { a: { b: { c: {} } } }
+    beforeEach(() => obj = { a: { b: { c: {} } } })
+
+    it("freezes nested objects", () => {
+      const froze = deepFreeze(obj)
+      expect(Object.isFrozen(froze)).toBe(true)
+      expect(froze).toStrictEqual({ a: { b: { c: {} } } })
+      expect(Object.isFrozen(froze.a)).toBe(true)
+      expect(Object.isFrozen(froze.a.b)).toBe(true)
+      expect(Object.isFrozen(froze.a.b.c)).toBe(true)
+    })
+
+    it("handles cycles", () => {
+      obj.a.b.c = obj
+      const froze = deepFreeze(obj)
+      expect(Object.isFrozen(froze.a.b.c)).toBe(true)
+    })
   })
 })

--- a/testing/tests/utils.test.ts
+++ b/testing/tests/utils.test.ts
@@ -1,0 +1,12 @@
+import { exists } from "../../lib/utils"
+
+
+describe("utils", () => {
+  describe("defined", () => {
+    it("returns false for null", () => expect(exists(null)).toStrictEqual(false))
+    it("returns false for undefined", () => expect(exists(undefined)).toStrictEqual(false))
+    it("returns true for an empty string", () => expect(exists("")).toStrictEqual(true))
+    it("returns true for 0", () => expect(exists(0)).toStrictEqual(true))
+    it("returns true for NaN", async () => expect(exists(0)).toStrictEqual(true))
+  })
+})

--- a/testing/tests/utils.test.ts
+++ b/testing/tests/utils.test.ts
@@ -11,7 +11,7 @@ describe("utils", () => {
   })
 
   describe("deepFreeze", () => {
-    let obj = { a: { b: { c: {} } } }
+    let obj: { a: { b: { c: {} } } }
     beforeEach(() => obj = { a: { b: { c: {} } } })
 
     it("freezes nested objects", () => {


### PR DESCRIPTION
This PR defines new entities and formalizes the API shared by client and server, as well as some supporting types and constants. 

These new entities are:

`Site`: Model of a particular website or app to for which to track metrics and run experiments
`Experiment`: A configured set of named variants to test
`Variant`: A specific variation of a site and the probability it will be presented to a user based on its metrics

These entities support the following flow:
- A user loads a website or app with Instant Bandit in it
- The `<InstantBandit>` component makes a request to an API endpoint such as `/api/site`
- The endpoint loads the full definition of the site (`SiteMeta`) from a backend store, e.g. Redis
- The endpoint selects an `Experiment` based on some criteria (date/time, locale, etc)
- The endpoint runs an algorithm to select a `Variant` from the experiment
- The model is "pruned" into a `Site` (no metrics or probabilities exposed) and served to the device
- The Instant Bandit components present the application according to the selected variant
- Metrics around exposures and conversions are tracked against the selected experiment and variant

For returning users, the experiments and variants presented to them previously are stored in their session and taken into account when serving the configuration.

This changeset also defines a default `Site` model: a site with one experiment and one variant, each bearing the reserved name `@default`. This default model represents a site in its unmodified or "invariant" state. In the absence of any site config, e.g. in the event of a network or server failure, or an app with no active experiments, the built-in defaults are used.

Client and servers can always safely assume a site to have a default experiment and default variant, even if they are not expressly configured. This is primarily for fault tolerance, but it also means that metrics can be tracked against the default variant when no experiments are active.
