### PR TITLE
Improve client metrics handling

### DIFF
--- a/lib/contexts.ts
+++ b/lib/contexts.ts
@@ -74,8 +74,8 @@ export const DEFAULT_BANDIT_OPTIONS: InstantBanditOptions = {
   sitePath: env(constants.VARNAME_SITE_PATH) ?? constants.DEFAULT_SITE_PATH,
   metricsPath: env(constants.VARNAME_METRICS_PATH) ?? constants.DEFAULT_METRICS_PATH,
   appendTimestamp: false,
-  batchSize: 10,
-  flushInterval: 50,
+  batchSize: 100,
+  flushInterval: 100,
   defaultAlgo: Algorithm.DEFAULT,
 
   // NOTE: These will need to be isomorphic for SSR

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -6,7 +6,7 @@
  * 
  */
 
-import { MetricEventPayload } from "./types";
+import { Metric } from "./types";
 
 
 /**
@@ -80,17 +80,22 @@ export interface PropsBucket {
 
 /**
  * An individual metric sample to report to a metrics sink such as a Redis backend.
- * 
- * Samples are associated with experiments and variants and aggregated into the
- * metrics buckets on the server side.
  */
 export interface MetricsSample {
   ts: number
-  site: string
+  name: string
+  payload?: Metric
+}
+
+/**
+ * A batch of individual metrics to send to the server at once
+ */
+
+export interface MetricsBatch {
   session: string
-  origin: string
+  site: string
   experiment: string
   variant: string
-  name: string
-  payload?: MetricEventPayload
+  token?: string
+  entries: MetricsSample[]
 }

--- a/lib/providers/metrics.ts
+++ b/lib/providers/metrics.ts
@@ -1,13 +1,142 @@
-import { InstantBanditOptions, MetricsProvider } from "../types";
-import { MetricsSample } from "../models";
+import * as constants from "../constants"
+import { InstantBanditOptions, Metric, MetricsProvider, TimerLike } from "../types"
+import { MetricsBatch, MetricsSample } from "../models"
+import { exists } from "../utils"
+import { DEFAULT_BANDIT_OPTIONS, InstantBanditContext } from "../contexts"
 
 
-export function getHttpMetricsSink(options: InstantBanditOptions) {
-  const sink: MetricsProvider = {
-    sink: (ctx, metric) => { },
-    sinkEvent: (ctx, name) => { },
-    flush: async () => { }
+export function getHttpMetricsSink(initOptions?: Partial<InstantBanditOptions>): MetricsProvider {
+  const options = Object.assign({}, DEFAULT_BANDIT_OPTIONS, initOptions)
+  const items: MetricsSample[] = []
+  let flushTimer: TimerLike | null = null
+
+  const provider = {
+    get pending() { return items.length },
+
+    sink(ctx: InstantBanditContext, sample: MetricsSample, forceFlush = false, useBeacon = false) {
+      items.push(sample)
+
+      if (forceFlush) {
+        return provider.flush(ctx)
+      } else {
+        provider.scheduleFlush(ctx)
+      }
+    },
+
+    sinkEvent(ctx: InstantBanditContext, eventName: string, payload?: Metric, forceFlush = false): void {
+      try {
+        const evt: MetricsSample = {
+          ts: new Date().getTime(),
+          name: eventName,
+          payload,
+        }
+
+        provider.sink(ctx, evt, forceFlush)
+      } catch (err) {
+        console.warn(`[IB] Error sinking event: ${err}`)
+      }
+    },
+
+    scheduleFlush(ctx) {
+      if (flushTimer) {
+        return
+      }
+
+      flushTimer = setTimeout(() =>
+        provider
+          .flush(ctx)
+          .catch(err => console.warn(err))
+        , options.flushInterval
+        )
+    },
+
+    async flush(ctx: InstantBanditContext, flushAll = false): Promise<void> {
+      const { baseUrl, batchSize, metricsPath } = options
+      const { session, site, experiment, variant } = ctx
+
+      // No where to send to? Discard.
+      if (!exists(metricsPath) || metricsPath.trim() === "") {
+        console.debug(`[IB] No metrics path configured`)
+        items.splice(0, items.length)
+        return
+      }
+
+      const count = flushAll
+        ? items.length
+        : Math.min(items.length, batchSize)
+
+      const entries = items.slice(0, count)
+      const sessionId = session.id ?? ""
+      const batch: MetricsBatch = {
+        session: sessionId,
+        site: site.name,
+        experiment: experiment.id!,
+        variant: variant.name,
+        entries: entries,
+      }
+
+      const url = new URL(metricsPath, baseUrl)
+
+      // Prefer `fetch` for general purpose logging, as it's more transparent than `sendBeacon`.
+      // Perfer `sendBeacon` for flushing all, i.e. when unmounting, as it's more likely to
+      // deliver metrics on page vis changes or unload events.
+      try {
+        if (flushAll &&
+          typeof navigator !== "undefined" &&
+          typeof navigator.sendBeacon !== "undefined") {
+          sendBatchViaBeacon(url, batch)
+        } else {
+          await sendBatchViaFetch(url, sessionId, batch)
+        }
+
+        items.splice(0, count)
+
+      } catch (err) {
+
+        // In the event of an error, metrics remain in the queue
+        console.warn(`Error occurred while flushing metrics: ${err}`)
+
+      } finally {
+
+        if (flushTimer) {
+          clearTimeout(flushTimer)
+          flushTimer = null
+        }
+
+        if (items.length > 0) {
+          provider.scheduleFlush(ctx)
+        }
+
+        return
+      }
+    }
   }
 
-  return sink
+  return provider
+}
+
+
+// Note: sendBeacon is synchronous (fire and forget), and will return `true` even in the case server error
+export function sendBatchViaBeacon(url: URL, batch: MetricsBatch) {
+  const blob = new Blob(
+    [JSON.stringify(batch)],
+    {
+      type: "application/json; charset=UTF-8",
+    }
+  )
+  return navigator.sendBeacon(url, blob)
+}
+
+export async function sendBatchViaFetch(url: URL, sessionId: string, batch: MetricsBatch) {
+  await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      "Accept": "application/json",
+      "Content-Type": "application/json",
+      [constants.HEADER_SESSION_ID]: sessionId,
+    },
+    body: JSON.stringify(batch),
+  })
+
+  return true
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,7 +3,7 @@ import { Experiment, MetricsBucket, MetricsSample, Site, Variant as VariantModel
 import { InstantBanditContext } from "./contexts"
 
 
-export interface InstantBanditProps {
+export type InstantBanditProps = {
   preserveSession?: boolean
   probabilities?: ProbabilityDistribution | null
   select?: string
@@ -14,7 +14,7 @@ export interface InstantBanditProps {
   onError?: (err?: Error, ctx?: InstantBanditContext) => void
 }
 
-export interface InstantBanditOptions {
+export type InstantBanditOptions = {
   baseUrl: string
   sitePath: string
   metricsPath: string
@@ -26,17 +26,11 @@ export interface InstantBanditOptions {
   algorithms: Algorithms
 }
 
-
-export interface Scope {
-  siteName: string
-  variant: VariantModel | null
-}
-
-export interface AlgorithmImpl<TAlgoArgs = unknown> {
+export type AlgorithmImpl<TAlgoArgs = unknown> = {
   select<TAlgoArgs>(args: TAlgoArgs & SelectionArgs): Promise<AlgorithmResults>
 }
 
-export interface SelectionArgs<TAlgoParams = unknown> {
+export type SelectionArgs<TAlgoParams = unknown> = {
   site: Site
   algo: Algorithm | string
   params: TAlgoParams | null
@@ -62,26 +56,27 @@ export enum Algorithm {
 }
 
 export type Algorithms = Record<string, AlgorithmImpl>
-export interface AlgorithmResults {
+export type AlgorithmResults = {
   pValue: number
   metrics: MetricsBucket
   winner: VariantModel
 }
 
-export interface SessionProvider {
+export type SessionProvider = {
   id: string | null
   getOrCreateSession(ctx: InstantBanditContext, props?: Partial<SessionDescriptor>): Promise<SessionDescriptor>
   persistVariant(ctx: InstantBanditContext, experiment: string, variant: string): Promise<void>
-  hasSeen(ctx: InstantBanditContext,experiment: string, variant: string): Promise<boolean>
+  hasSeen(ctx: InstantBanditContext, experiment: string, variant: string): Promise<boolean>
 }
 
-export interface MetricsProvider {
-  sink(ctx: InstantBanditContext, metric: MetricsSample): void
-  sinkEvent(ctx: InstantBanditContext, name: string): void
-  flush(ctx: InstantBanditContext): Promise<void>
+export type MetricsProvider = {
+  readonly pending: number
+  sink(ctx: InstantBanditContext, metric: MetricsSample, flushImmediate?: boolean): void
+  sinkEvent(ctx: InstantBanditContext, name: string, payload?: Metric, flush?: boolean): void
+  flush(ctx: InstantBanditContext, flushAll?: boolean): Promise<void>
 }
 
-export interface SiteProvider {
+export type SiteProvider = {
   state: LoadState
   error: Error | null
   model: Site
@@ -103,7 +98,7 @@ export type Providers = {
  * Describes a user session, scoped per origin and site.
  * Includes the selected variant for the current site.
  */
-export interface SessionDescriptor {
+export type SessionDescriptor = {
   site: string | null
   variants: { [experiment: string]: string[] }
 
@@ -137,5 +132,5 @@ export type PValue = number
 export type TimerLike = any
 
 
-export type Metric = DefaultMetrics | string
-export type MetricEventPayload = string | number | object
+export type MetricName = DefaultMetrics | string
+export type Metric = string | number | object

--- a/testing/tests/components/InstantBanditComponent.test.tsx
+++ b/testing/tests/components/InstantBanditComponent.test.tsx
@@ -14,6 +14,7 @@ import { InstantBanditContext } from "../../../lib/contexts"
 import { SessionProvider } from "../../../lib/types"
 import { DEFAULT_EXPERIMENT } from "../../../lib/defaults"
 import { Experiment } from "../../../lib/models"
+import { DefaultMetrics } from "../../../lib/constants"
 
 
 describe("InstantBandit component", () => {
@@ -177,6 +178,32 @@ describe("InstantBandit component", () => {
       )
       expect(fetches).toStrictEqual(1)
       expect(callbackResult).toBeDefined()
+    })
+  })
+
+  describe("metrics", () => {
+    it("records an exposure on mount", async () => {
+      let pending = 0
+      await renderTest(
+        <InstantBandit onReady={ctx => {
+         pending = ctx.metrics.pending
+        }} />
+      )
+      expect(pending).toBe(1)
+    })
+
+    it("flushes metrics on unmount", async () => {
+      let flushes = 0
+      const component = await renderTest(
+        <InstantBandit onReady={ctx => {
+          jest.spyOn(ctx.metrics, "flush").mockImplementation(async () => {
+            ++flushes
+          })
+        }} />
+      )
+      expect(flushes).toBe(0)
+      component.unmount()
+      expect(flushes).toBe(1)
     })
   })
 })

--- a/testing/tests/metrics.client.test.ts
+++ b/testing/tests/metrics.client.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @jest-environment jsdom
+ */
+import fetchMock from "jest-fetch-mock"
+
+import { InstantBanditContext, createBanditContext } from "../../lib/contexts"
+import { MetricsBatch, MetricsSample } from "../../lib/models"
+import { InstantBanditOptions, MetricsProvider } from "../../lib/types"
+import { getHttpMetricsSink } from "../../lib/providers/metrics"
+import { exists } from "../../lib/utils"
+import { TEST_SITE_AB } from "../sites"
+import { DEFAULT_SITE } from "../../lib/defaults"
+
+
+describe("metrics (client)", () => {
+  let url: URL
+  let ctx: InstantBanditContext
+  let fetches = 0
+  let flushes = 0
+  let metrics: MetricsProvider
+  let oldSendBeacon = navigator.sendBeacon
+  let sendBeaconContent: Promise<string>
+
+  const TEST_OPTIONS: Partial<InstantBanditOptions> = {
+    batchSize: 10,
+    flushInterval: 10,
+  }
+
+  const TEST_SITE = TEST_SITE_AB
+
+  beforeAll(() => {
+    fetchMock.enableMocks()
+  })
+
+  afterAll(() => {
+    fetchMock.resetMocks()
+  })
+
+  beforeEach(() => {
+    fetches = 0
+    flushes = 0
+    ctx = createBanditContext()
+    metrics = getHttpMetricsSink(TEST_OPTIONS)
+    mockSendBeacon()
+  })
+
+  afterEach(() => {
+    resetSendBeacon()
+  })
+
+  const TEST_METRIC: MetricsSample = {
+    ts: new Date().getTime(),
+    name: "click",
+    payload: "button.get-started",
+  }
+
+  async function flushed() {
+    return new Promise<void>((resolve, reject) => {
+      jest.spyOn(metrics, "flush").mockImplementationOnce(async () => {
+        ++flushes
+        resolve()
+      })
+    })
+  }
+
+  describe("sink", () => {
+    it("sends a message to the metrics endpoint", async () => {
+      let json: MetricsBatch
+      fetchMock.mockResponseOnce(async req => {
+        url = new URL(req.url)
+        ++fetches
+        json = JSON.parse(req.body!.toString())
+        return "{}"
+      })
+
+      metrics.sink(ctx, TEST_METRIC)
+      await metrics.flush(ctx)
+
+      expect(exists(json!)).toBe(true)
+      expect(json!.site).toBe(DEFAULT_SITE.name)
+      expect(json!.entries.length).toBeGreaterThan(0)
+    })
+
+    it("causes an asynchronous flush", async () => {
+      expect(flushes).toBe(0)
+      metrics.sink(ctx, TEST_METRIC)
+      expect(flushes).toBe(0)
+      await flushed()
+      expect(flushes).toBe(1)
+    })
+
+    it("flushes immediately if specified", async () => {
+      expect(flushes).toBe(0)
+      jest.spyOn(metrics, "flush").mockImplementationOnce(async () => {
+        ++flushes
+      })
+      metrics.sink(ctx, TEST_METRIC, true)
+      expect(flushes).toBe(1)
+    })
+  })
+
+  describe("batching", () => {
+    it("batches messages together", async () => {
+      Array(10).fill(0).forEach(() => metrics.sink(ctx, TEST_METRIC))
+      expect(flushes).toBe(0)
+      await flushed()
+      expect(flushes).toBe(1)
+    })
+  })
+
+  describe("flushing", () => {
+    it("drains the queue of metrics", async () => {
+      expect(metrics.pending).toBe(0)
+
+      Array(10).fill(0).forEach(() => metrics.sink(ctx, TEST_METRIC))
+      expect(metrics.pending).toBe(10)
+
+      await metrics.flush(ctx)
+      expect(metrics.pending).toBe(0)
+    })
+
+    it("uses sendBeacon when passed flushAll = true", async () => {
+      mockSendBeacon()
+      metrics.sink(ctx, TEST_METRIC)
+      await metrics.flush(ctx, true)
+      const body = await sendBeaconContent
+      expect(exists(body))
+      const batch = JSON.parse(body) as MetricsBatch
+      expect(batch.entries.length).toBe(1)
+    })
+
+    it("doesn't throw on network failure (fetch)", async () => {
+      fetchMock.mockRejectOnce(() => Promise.reject(new Error("MOCK-FLUSH-FAILURE")))
+      metrics.sink(ctx, TEST_METRIC)
+      await metrics.flush(ctx)
+      expect(true)
+    })
+
+    it("doesn't throw on network failure (sendBeacon)", async () => {
+      mockSendBeaconError()
+      metrics.sink(ctx, TEST_METRIC)
+      await metrics.flush(ctx, true)
+      expect(true)
+    })
+  })
+
+
+  function mockSendBeacon() {
+    (navigator as any)["sendBeacon"] = (url, content) => {
+      ++fetches
+      url = new URL(url)
+      sendBeaconContent = readBlob(content)
+      return true
+    }
+  }
+
+  function mockSendBeaconError() {
+    (navigator as any)["sendBeacon"] = (url, content) => {
+      throw new Error("FAKE-SENDBEACON-ERROR")
+    }
+  }
+
+  function resetSendBeacon() {
+    (navigator as any)["sendBeacon"] = oldSendBeacon
+  }
+
+  function readBlob(blob) {
+    return new Promise<any>((resolve, rej) => {
+      const reader = new FileReader()
+      reader.onload = function (event) {
+        resolve(reader.result)
+      }
+      reader.readAsText(blob)
+    })
+  }
+})


### PR DESCRIPTION
Metrics are now batched and associated with user sessions, site/experiment/variant, and timestamped.