### PR TITLE
 Minor DX/testing tweaks

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,3 +1,16 @@
 // Adapted from https://dev.to/maciekgrzybek/setup-next-js-with-typescript-jest-and-react-testing-library-28g5
 import "@testing-library/jest-dom"
 import "jest-localstorage-mock"
+
+
+
+global.console = {
+  ...console,
+  
+  // Disable log messages by default
+  log: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}

--- a/lib/server/backends/sessions.ts
+++ b/lib/server/backends/sessions.ts
@@ -23,6 +23,7 @@ export function getStubSessionsBackend(): SessionsBackend {
         session = sessions[sid!]
         if (!exists(session)) {
           console.warn(`[IB] Missing or expired session '${sid}'`)
+          session = null
         }
       }
 
@@ -45,7 +46,6 @@ export function getStubSessionsBackend(): SessionsBackend {
       if (ix > -1) {
         variants.splice(ix, 1)
       }
-
       variants.push(variantName)
 
       return session

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+
+  // Note: Using strict mode in development is good practice.
+  // However, be aware that this interntionally causes double renders,
+  // and therefore can be confusing when diagnosing flicker/CLS issues.
+  reactStrictMode: false,
 }
 
 module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "up": "yarn dc up -d",
     "rc": "yarn dc exec redis redis-cli",
     "rct": "yarn dc exec redis-testing redis-cli",
-    "dev": "yarn dc up -d && NODE_OPTIONS='--inspect=localhost:9229' next dev",
+    "dev": "NODE_OPTIONS='--inspect=localhost:9229' next dev && yarn dc up -d",
     "build": "next build",
     "start": "next start",
     "test": "jest --verbose"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "up": "yarn dc up -d",
     "rc": "yarn dc exec redis redis-cli",
     "rct": "yarn dc exec redis-testing redis-cli",
-    "dev": "NODE_OPTIONS='--inspect=localhost:9229' next dev && yarn dc up -d",
+    "dev": "yarn dc up -d && NODE_OPTIONS='--inspect=localhost:9229' next dev",
     "build": "next build",
     "start": "next start",
     "test": "jest --verbose"


### PR DESCRIPTION
Disable strict mode as it makes debugging flicker tricky due to double-renders. Suppress console output in tests. Start Redis before `next dev`.
