### PR TITLE
Add static sites helper

### DIFF
--- a/lib/server/backends/static-sites.ts
+++ b/lib/server/backends/static-sites.ts
@@ -1,8 +1,14 @@
+import fs from "fs"
+import path from "path"
+import { cwd } from "process"
+
 import env from "../environment"
 import { ModelsBackend, ValidatedRequest } from "../server-types"
 import { Site } from "../../models"
 import { DEFAULT_SITE } from "../../defaults"
-import { DEMO_SITE } from "../../sites"
+import { TimerLike } from "../../types"
+
+const asyncfs = fs.promises
 
 
 export type JsonSiteBackendOptions = {
@@ -10,13 +16,11 @@ export type JsonSiteBackendOptions = {
   /** Base path to load sites from */
   basePath: string,
 
-  /** Minimum time in ms to wait before reloading a site from disk */
+  /**
+   * Minimum time in ms to wait before reloading a site from disk.
+   * Set to -1 for no reloading.
+   */
   refreshInterval: number,
-
-  /** Map of site names to local paths */
-  sites: {
-    [siteName: string]: string,
-  }
 }
 
 /**
@@ -24,24 +28,87 @@ export type JsonSiteBackendOptions = {
  */
 export function getStaticSiteBackend(initOptions: Partial<JsonSiteBackendOptions> = {}): ModelsBackend {
   const options = Object.assign({}, DEFAULT_STATIC_SITE_BACKEND_OPTIONS, initOptions)
-  return {
-    async getSiteConfig(req: ValidatedRequest): Promise<Site> {
+  let sites: { [name: string]: Site } = {}
+  let lastScan = 0
 
-      // STUB
-      if (req.siteName === "demo") {
-        return DEMO_SITE
-      } else {
+  function logError(err: Error) {
+    console.warn(`[IB] Error scanning sites: ${err}`)
+  }
+
+  return {
+    async connect() {
+      try {
+        sites = await scanSites(env.IB_STATIC_SITES_PATH, sites, lastScan)
+      } catch (err) {
+        logError(err)
+      }
+    },
+
+    async getSiteConfig(req: ValidatedRequest): Promise<Site> {
+      const { siteName } = req
+      const { refreshInterval } = options
+      const now = new Date().getTime()
+
+      if (refreshInterval !== -1 && (now - lastScan > refreshInterval)) {
+
+        // Don't hold up the show.
+        scanSites(env.IB_STATIC_SITES_PATH, sites, lastScan)
+          .then(scanned => sites = scanned)
+          .then(() => lastScan = now)
+          .catch(logError)
+      }
+
+      const site = sites[siteName ?? DEFAULT_SITE.name]
+      if (!site) {
         return DEFAULT_SITE
+      } else {
+        return site
       }
     }
   }
 }
 
+/**
+ * Scans the public sites folder, reloading any modified sites.
+ * Observes a configurable interval so as to not cause unnecessary IO.
+ */
+export async function scanSites(folder: string, sites: { [name: string]: Site } = {}, lastScan: number = 0) {
+  try {
+    await asyncfs.stat(folder)
+  } catch (err) {
+    console.warn(`[IB] Public sites folder does not exist`)
+    return sites
+  }
+
+  const files = await asyncfs.readdir(folder)
+  const jsonFiles = files.filter(name => name.endsWith(".json"))
+  const root = path.join(cwd(), folder)
+
+  for (const jsonFile of jsonFiles) {
+    const siteName = jsonFile.replace(".json", "")
+    const fullPath = path.join(root, jsonFile)
+    const stat = await asyncfs.stat(fullPath)
+    const { mtimeMs } = stat
+
+    if (mtimeMs < lastScan) {
+      continue
+    }
+
+    try {
+      const jsonBuffer = await asyncfs.readFile(fullPath)
+      const jsonStr = jsonBuffer.toString("utf-8")
+      const json = JSON.parse(jsonStr)
+
+      sites[siteName] = json
+    } catch (err) {
+      console.warn(`[IB] Error reading '${folder}/${jsonFile}': ${err}`)
+    }
+  }
+
+  return sites
+}
+
 export const DEFAULT_STATIC_SITE_BACKEND_OPTIONS: JsonSiteBackendOptions = {
   basePath: env.IB_STATIC_SITES_PATH,
   refreshInterval: 10 * 1000,
-  sites: {
-    "default": "default.json",
-    "demo": "demo.json",
-  }
 }

--- a/lib/server/backends/static-sites.ts
+++ b/lib/server/backends/static-sites.ts
@@ -49,7 +49,11 @@ export function getStaticSiteBackend(initOptions: Partial<JsonSiteBackendOptions
       const { refreshInterval } = options
       const now = new Date().getTime()
 
-      if (refreshInterval !== -1 && (now - lastScan > refreshInterval)) {
+      // Only scan the folder for updated sites if the configured interval has elapsed
+      const useRefreshInterval = refreshInterval > -1
+      const intervalElapsed = (now - lastScan > refreshInterval)
+
+      if (useRefreshInterval && intervalElapsed) {
 
         // Don't hold up the show.
         scanSites(env.IB_STATIC_SITES_PATH, sites, lastScan)
@@ -59,11 +63,10 @@ export function getStaticSiteBackend(initOptions: Partial<JsonSiteBackendOptions
       }
 
       const site = sites[siteName ?? DEFAULT_SITE.name]
-      if (!site) {
-        return DEFAULT_SITE
-      } else {
+      if (site) {
         return site
       }
+      return DEFAULT_SITE
     }
   }
 }

--- a/lib/server/environment.ts
+++ b/lib/server/environment.ts
@@ -7,7 +7,7 @@ const defaults = {
   IB_ORIGINS_ALLOWLIST: process.env.NODE_ENV === "production" ? "" : DEFAULT_BASE_URL,
   IB_REDIS_HOST: "localhost",
   IB_REDIS_PORT: 6379,
-  IB_STATIC_SITES_PATH: "./",
+  IB_STATIC_SITES_PATH: "./public/sites",
   IB_MAX_METRICS_PAYLOAD_LEN: 1024,
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,7 +31,7 @@ export default function Home(serverSideProps: InstantBanditOptions) {
 
       <main className={styles.main}>
         <h1 className={styles.header}>Welcome to Instant Bandit</h1>
-        <InstantBandit {...serverSideProps} siteName={siteName}>
+        <InstantBandit {...serverSideProps}>
 
           <Default>
             <h2>You are currently viewing the default variant</h2>
@@ -90,6 +90,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return {
     props: {
       site,
+      siteName,
       select,
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     "**/*.tsx"
   ],
   "exclude": [
-    "dist",
-    "node_modules"
+    "**/dist",
+    "**/node_modules"
   ]
 }


### PR DESCRIPTION
Adds a helper that serves site JSON files out of _public/sites_. Useful in a host repo so implementers don't have to serve config themselves.