### PR TITLE
Add new SWC support via Next 12

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["next/babel"]
-}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,6 @@
-// Adapted from https://dev.to/maciekgrzybek/setup-next-js-with-typescript-jest-and-react-testing-library-28g5
-module.exports = {
+const nextJest = require("next/jest")
+const createJestConfig = nextJest({ dir: "./" })
+const customJestConfig = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
-  testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/"],
-  // NOTE: this is only here because of redis issue.
-  // See https://github.com/luin/ioredis/issues/1088
-  forceExit: true,
 }
+module.exports = createJestConfig(customJestConfig)

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,8 @@ const nextConfig = {
   // However, be aware that this interntionally causes double renders,
   // and therefore can be confusing when diagnosing flicker/CLS issues.
   reactStrictMode: false,
+
+  swcMinify: true,
 }
 
 module.exports = nextConfig

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "esnext"
     ],
     "target": "es5",
-    "module": "esnext",
+    "module": "commonjs",
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,


### PR DESCRIPTION
Enables `swc` in Next.js 12, which applies here to the Next app in the repo, but not the TypeScript we export in the package build, which is uncoupled from next. Regardless, the prod build of the host app dropped by 50%. Nice. No significant changes in final bundle size.

