### PR TITLE
Session improvements

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -3,6 +3,7 @@ export const DEFAULT_SITE_ID = DEFAULT_NAME;
 export const DEFAULT_SITE_NAME = DEFAULT_NAME;
 export const DEFAULT_EXPERIMENT_ID = DEFAULT_NAME;
 export const DEFAULT_EXPERIMENT_NAME = DEFAULT_NAME;
+export const DEFAULT_VARIANT_ID = DEFAULT_NAME;
 export const DEFAULT_VARIANT_NAME = DEFAULT_NAME;
 export const DEFAULT_ORIGIN = "localhost";
 export const DEFAULT_BASE_URL = "http://localhost:3000";

--- a/lib/providers/site.ts
+++ b/lib/providers/site.ts
@@ -2,14 +2,13 @@
 import * as constants from "../constants";
 import {
   LoadState,
-  SessionDescriptor,
   Selection,
   SiteProvider,
   ProbabilityDistribution,
 } from "../types";
 import { Experiment, Site, Variant } from "../models";
 import { InstantBanditContext } from "../contexts";
-import { env, exists, getCookie, isBrowserEnvironment } from "../utils";
+import { env, exists, isBrowserEnvironment } from "../utils";
 import {
   DEFAULT_EXPERIMENT,
   DEFAULT_OPTIONS,
@@ -166,10 +165,10 @@ export function getSiteProvider(initOptions: Partial<SiteProviderOptions> = {}):
           variant = result.variant;
         } else if (session) {
           const userSession = session.getOrCreateSession(ctx);
-          const { variants } = userSession;
-          const variantsSeenForExperiment = variants?.[experiment.id];
-          const previouslySeenVariant = variantsSeenForExperiment?.reverse()[0];
-          variant = experiment.variants.find(v => v.name === previouslySeenVariant) ?? null;
+          const { selections } = userSession;
+          const selectedSite = selections[site.name];
+          const mostRecentSeenVariant = selectedSite?.[experiment.id]?.reverse()[0];
+          variant = experiment.variants.find(v => v.name === mostRecentSeenVariant) ?? null;
         }
 
         if (!variant) {

--- a/lib/providers/site.ts
+++ b/lib/providers/site.ts
@@ -167,7 +167,7 @@ export function getSiteProvider(initOptions: Partial<SiteProviderOptions> = {}):
           const userSession = session.getOrCreateSession(ctx);
           const { selections } = userSession;
           const selectedSite = selections[site.name];
-          const mostRecentSeenVariant = selectedSite?.[experiment.id]?.reverse()[0];
+          const mostRecentSeenVariant = selectedSite?.[experiment.id]?.slice().reverse()[0];
           variant = experiment.variants.find(v => v.name === mostRecentSeenVariant) ?? null;
         }
 

--- a/lib/server/backends/redis.ts
+++ b/lib/server/backends/redis.ts
@@ -18,7 +18,7 @@ import {
 } from "../../models";
 import { ConnectingBackendFunctions, MetricsBackend, SessionsBackend, ValidatedRequest } from "../server-types";
 import { makeKey, toNumber } from "../server-utils";
-import { exists } from "../../utils";
+import { exists, markVariantInSession } from "../../utils";
 import { UUID_LENGTH } from "../../constants";
 
 
@@ -129,7 +129,7 @@ export async function getOrCreateSession(redis: Redis, req: ValidatedRequest): P
   let session: SessionDescriptor | null = null;
 
   if (exists(sid) && sid.length === UUID_LENGTH) {
-    const sessionKey = makeKey([siteName, "session", sid]);
+    const sessionKey = makeKey(["session", sid]);
     const sessionRaw = await redis.get(sessionKey);
 
     if (!exists(sessionRaw)) {
@@ -168,7 +168,6 @@ export async function getOrCreateSession(redis: Redis, req: ValidatedRequest): P
 export async function markVariantSeen(redis: Redis, session: SessionDescriptor, site: string, experimentId: string, variantName: string) {
 
   markVariantInSession(session, site, experimentId, variantName);
-
   const serializedSession = JSON.stringify(session);
   const sessionKey = makeKey(["session", session.sid]);
   try {

--- a/lib/server/backends/sessions.ts
+++ b/lib/server/backends/sessions.ts
@@ -34,8 +34,8 @@ export function getStubSessionsBackend(): SessionsBackend {
       return session;
     },
 
-    async markVariantSeen(session: SessionDescriptor, site: Site, experiment: string, variant: string) {
-      markVariantInSession(session, site.name, experiment, variant);
+    async markVariantSeen(session: SessionDescriptor, site: string, experiment: string, variant: string) {
+      markVariantInSession(session, site, experiment, variant);
 
       return session;
     }

--- a/lib/server/backends/sessions.ts
+++ b/lib/server/backends/sessions.ts
@@ -2,7 +2,8 @@ import { randomUUID } from "crypto";
 
 import { SessionsBackend, ValidatedRequest } from "../server-types";
 import { SessionDescriptor } from "../../types";
-import { exists } from "../../utils";
+import { exists, makeNewSession, markVariantInSession } from "../../utils";
+import { Site } from "../../models";
 
 
 export function getStubSessionsBackend(): SessionsBackend {
@@ -11,7 +12,7 @@ export function getStubSessionsBackend(): SessionsBackend {
 
     async getOrCreateSession(req: ValidatedRequest): Promise<SessionDescriptor> {
       const { siteName } = req;
-      let { sid } = req;
+      const { sid } = req;
 
       if (!exists(siteName)) {
         throw new Error(`Invalid session scope`);
@@ -27,25 +28,14 @@ export function getStubSessionsBackend(): SessionsBackend {
       }
 
       if (!session) {
-        sid = randomUUID();
-        session = sessions[sid] = {
-          sid,
-          site: siteName ?? null,
-          variants: {},
-        };
+        return makeNewSession(randomUUID());
       }
+
       return session;
     },
 
-    async markVariantSeen(session: SessionDescriptor, experimentId: string, variantName: string) {
-      const variants = session.variants[experimentId] || [];
-
-      // Put the most recently presented variant at the end
-      const ix = variants.indexOf(variantName);
-      if (ix > -1) {
-        variants.splice(ix, 1);
-      }
-      variants.push(variantName);
+    async markVariantSeen(session: SessionDescriptor, site: Site, experiment: string, variant: string) {
+      markVariantInSession(session, site.name, experiment, variant);
 
       return session;
     }

--- a/lib/server/server-core.ts
+++ b/lib/server/server-core.ts
@@ -108,19 +108,13 @@ export function buildInstantBanditServer(initOptions?: Partial<InstantBanditServ
      * Produces a site object bearing probabilities and ready for consumer selection
      */
     async getSite(req: ValidatedRequest): Promise<ApiSiteResponse> {
-      const { getOrCreateSession } = sessions;
       const { getSiteConfig } = models;
 
-      const session = await getOrCreateSession(req);
       const siteConfig = await getSiteConfig(req);
       const siteWithProbs = await embedProbabilities(req, siteConfig, metrics);
 
-      const responseHeaders: OutgoingHttpHeaders = {
-        "Set-Cookie": emitCookie(req, session)
-      };
-
       return {
-        responseHeaders,
+        responseHeaders: {},
         site: siteWithProbs,
       };
     }

--- a/lib/server/server-core.ts
+++ b/lib/server/server-core.ts
@@ -39,8 +39,6 @@ export const DEFAULT_SERVER_OPTIONS: Partial<InstantBanditServerOptions> = {
  * @private
  */
 export function buildInstantBanditServer(initOptions?: Partial<InstantBanditServerOptions>): InstantBanditServer {
-  console.debug(`[IB] createInstantBanditServer invoked from ${__dirname}`);
-
   const options = Object.assign({}, DEFAULT_SERVER_OPTIONS, initOptions);
 
   // Only instantiate the backends if needed

--- a/lib/server/server-rendering.ts
+++ b/lib/server/server-rendering.ts
@@ -1,0 +1,88 @@
+import { IncomingMessage } from "http";
+import { InstantBanditServer } from "./server-types";
+import { HEADER_SESSION_ID } from "../constants";
+import { createBanditContext, DEFAULT_BANDIT_OPTIONS } from "../contexts";
+import { SessionDescriptor } from "../types";
+import { exists, makeNewSession } from "../utils";
+import { validateUserRequest } from "./server-utils";
+
+/**
+ * Handles details around serving a site in a manner suitable for a full SSR render.
+ * The selection is persisted in the server's session store, and a session ID is
+ * returned to the user via cookie.
+ */
+export async function serverSideRenderedSite(
+  server: InstantBanditServer,
+  siteName: string,
+  req: IncomingMessage & { cookies: { [key: string]: string } },
+) {
+  await server.init();
+
+  const validatedRequest = await validateUserRequest({
+    allowNoSession: true,
+    allowedOrigins: server.origins,
+    headers: req.headers,
+    siteName,
+    url: req.url,
+  });
+
+  const sid: string | null = null;
+  if (exists(req.cookies[HEADER_SESSION_ID])) {
+    validatedRequest.sid = req.cookies[HEADER_SESSION_ID];
+  }
+
+  const { sessions } = server;
+  let session: SessionDescriptor;
+  try {
+    session = await sessions.getOrCreateSession(validatedRequest);
+  } catch (err) {
+    console.log(`[IB] Error fetching session for '${sid}': ${err}`);
+    session = makeNewSession();
+  }
+
+  const { loader, metrics } = DEFAULT_BANDIT_OPTIONS.providers;
+  const ctx = createBanditContext({
+    providers: {
+      loader,
+      metrics,
+
+      //
+      // Here we inject the session from the server's asynchronous session store into
+      // the InstantBandit component's *synchronous* store. This is done for SSR.
+      //
+      // In order to complete the render entirely on the server and avoid client-side
+      // hydration, the component needs to render synchronously in one pass.
+      //
+      session: () => {
+        return {
+          id: session.sid,
+          getOrCreateSession: () => session,
+          hasSeen() {
+            return false;
+          },
+          persistVariant() {
+            // We do this server side below
+            return;
+          },
+          save: () => session,
+        };
+      },
+    },
+  });
+
+  // Call the backend directly for the site and skip an HTTP request
+  const { site: siteConfig } = await server.getSite(validatedRequest);
+  const site = await ctx.init(siteConfig);
+
+  const { experiment, variant } = ctx;
+
+
+  // Skip awaiting to avoid a round-trip to some backend
+  server.sessions.markVariantSeen(session, site.name, experiment.id, variant.name)
+    .catch(err => console.warn(`[IB]: Error marking variant '${variant.name}' seen: ${err}`));
+
+  return {
+    site,
+    select: variant.name,
+  };
+}

--- a/lib/server/server-types.ts
+++ b/lib/server/server-types.ts
@@ -61,7 +61,7 @@ export type MetricsBackend<TOptions = unknown> = BackendFunctions<TOptions> & {
  */
 export type SessionsBackend = BackendFunctions & {
   getOrCreateSession(req: ValidatedRequest): Promise<SessionDescriptor>
-  markVariantSeen(session: SessionDescriptor, experimentId: string, variantName: string)
+  markVariantSeen(session: SessionDescriptor, site: Site, experimentId: string, variantId: string)
     : Promise<SessionDescriptor>
 };
 

--- a/lib/server/server-types.ts
+++ b/lib/server/server-types.ts
@@ -61,7 +61,7 @@ export type MetricsBackend<TOptions = unknown> = BackendFunctions<TOptions> & {
  */
 export type SessionsBackend = BackendFunctions & {
   getOrCreateSession(req: ValidatedRequest): Promise<SessionDescriptor>
-  markVariantSeen(session: SessionDescriptor, site: Site, experimentId: string, variantId: string)
+  markVariantSeen(session: SessionDescriptor, site: string, experimentId: string, variantId: string)
     : Promise<SessionDescriptor>
 };
 

--- a/lib/server/server-utils.ts
+++ b/lib/server/server-utils.ts
@@ -11,7 +11,7 @@ import {
 } from "./server-types";
 import { MetricsBatch } from "../models";
 import { SessionDescriptor } from "../types";
-import { exists, getCookie } from "../utils";
+import { exists, getCookie, makeNewSession } from "../utils";
 import { DEFAULT_SITE } from "../defaults";
 
 
@@ -88,14 +88,9 @@ export async function validateUserRequest(args: RequestValidationArgs): Promise<
 }
 
 
-export async function createNewClientSession(origin: string, site: string): Promise<SessionDescriptor> {
+export async function createNewClientSession(): Promise<SessionDescriptor> {
   const sid = randomUUID();
-  const session: SessionDescriptor = {
-    site,
-    sid,
-    variants: {},
-  };
-
+  const session = makeNewSession(sid);
   return session;
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -54,6 +54,7 @@ export type SessionProvider = {
   getOrCreateSession(ctx: InstantBanditContext, props?: Partial<SessionDescriptor>): SessionDescriptor
   persistVariant(ctx: InstantBanditContext, experiment: string, variant: string): void
   hasSeen(ctx: InstantBanditContext, experiment: string, variant: string): boolean
+  save(ctx: InstantBanditContext, session: SessionDescriptor): SessionDescriptor
 };
 
 export type MetricsSinkOptions = BaseOptions & {
@@ -88,15 +89,15 @@ export type Providers = {
 };
 
 /**
- * Describes a user session, scoped per origin and site.
- * Includes the selected variant for the current site.
+ * Describes a user session and the Instant Bandit sites/experiments/variants presented to them.
  */
 export type SessionDescriptor = {
-  site: string | null
-  variants: { [experiment: string]: string[] }
-
-  // Session and user IDs
-  sid: string
+  sid: string;
+  selections: {
+    [siteId: string]: {
+      [experimentId: string]: string[],
+    };
+  };
 };
 
 export type VariantName = string;
@@ -107,11 +108,6 @@ export type Counts = {
   [variant: string]: number
 };
 
-export type ProbabilitiesResponse = {
-  name: string
-  probabilities: ProbabilityDistribution | null
-  pValue: PValue | null
-};
 
 // p-value of difference between variants
 export type PValue = number;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,7 +1,48 @@
 import { useEffect, useLayoutEffect } from "react";
 
 import * as constants from "./constants";
+import { SessionDescriptor } from "./types";
 
+
+export function makeNewSession(sid = "") {
+  const session: SessionDescriptor = {
+    sid,
+    selections: {},
+  };
+
+  return session;
+}
+
+export function markVariantInSession(
+  session: SessionDescriptor,
+  site: string, experiment: string,
+  variant: string) {
+
+  let sites = session.selections;
+  if (!sites) {
+    sites = session.selections = {};
+  }
+
+  let experiments = sites[site];
+  if (!experiments) {
+    experiments = sites[site] = {
+      [experiment]: [],
+    };
+  }
+
+  let variants = experiments[experiment];
+  if (!exists(variants)) {
+    variants = experiments[experiment] = [];
+  }
+
+  // Put the most recently presented variant at the end
+  const ix = variants.indexOf(variant);
+  if (ix > -1) {
+    variants.splice(ix, 1);
+  }
+
+  variants.push(variant);
+}
 
 /**
  * Freezes an entire object tree

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "scripts": {
     "dc": "docker-compose -f docker-compose.dev.yml",
     "up": "yarn dc up -d",
-    "rc": "yarn dc exec redis redis-cli",
-    "rct": "yarn dc exec redis-testing redis-cli",
+    "rc": "yarn -s dc exec -T redis redis-cli",
+    "rct": "yarn -s dc exec -T redis-testing redis-cli",
     "dev": "NODE_OPTIONS='--inspect=localhost:9229' next dev && yarn dc up -d",
     "compile": "tsc -p tsconfig.publish.json",
     "minify": "swc ./dist -s false -d ./dist",

--- a/pages/api/metrics.ts
+++ b/pages/api/metrics.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { MetricsBatch } from "../../lib/models";
 import { getInternalDevServer } from "../../lib/server/server-internal";
 import { InstantBanditHeaders, InstantBanditServer, ServerSession } from "../../lib/server/server-types";
-import { emitCookie, getSessionIdFromHeaders, validateUserRequest  } from "../../lib/server/server-utils";
+import { emitCookie, getSessionIdFromHeaders, validateUserRequest } from "../../lib/server/server-utils";
 
 
 const MetricsEndpoint = createMetricsEndpoint();
@@ -46,7 +46,8 @@ export function createMetricsEndpoint(server?: InstantBanditServer) {
 
       await metrics.ingestBatch(validatedReq, req.body);
 
-      if (needsSession) {
+      // Grant a session if the request needs one (is new), or if we created a new one
+      if (needsSession || session.sid !== sid) {
         res.setHeader("Set-Cookie", emitCookie(validatedReq, session));
       }
 

--- a/pages/api/metrics.ts
+++ b/pages/api/metrics.ts
@@ -50,7 +50,7 @@ export function createMetricsEndpoint(server?: InstantBanditServer) {
       validatedReq.session = session as ServerSession;
 
       await metrics.ingestBatch(validatedReq, req.body);
-      res.status(200).json({ status: "OK" });
+      res.status(200).json(session);
       return;
 
     } else {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -81,7 +81,7 @@ export function SignUpButton(props: { children?: ReactNode }) {
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const server = getInternalDevServer();
   const { req, res } = context;
-  const { site, select } = await serverSideRenderedSite(server, siteName, req, res);
+  const { site, select } = await serverSideRenderedSite(server, siteName, req);
 
   return {
     props: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import { Variant } from "../components/Variant";
 import { useInstantBandit } from "../lib/hooks";
 import { HEADER_SESSION_ID } from "../lib/constants";
 import { getInternalDevServer } from "../lib/server/server-internal";
-import { serverSideRenderedSite } from "../server";
+import { serverSideRenderedSite } from "../lib/server/server-rendering";
 import { InstantBanditOptions } from "../lib/types";
 
 import styles from "../styles/Home.module.css";

--- a/server.ts
+++ b/server.ts
@@ -1,20 +1,9 @@
-import { IncomingMessage, ServerResponse } from "http";
-import { NextApiRequestCookies } from "next/dist/server/api-utils";
-import { randomUUID } from "crypto";
-
-import { InstantBanditServer } from "./lib/server/server-types";
-import { SessionDescriptor } from "./lib/types";
-import { createBanditContext, DEFAULT_BANDIT_OPTIONS } from "./lib/contexts";
-import { emitCookie, validateUserRequest } from "./lib/server/server-utils";
-import { exists, makeNewSession } from "./lib/utils";
-import { HEADER_SESSION_ID } from "./lib/constants";
-
-
 import env from "./lib/server/environment";
 export { env };
 
 export * from "./lib/server/environment";
 export * from "./lib/server/server-core";
+export * from "./lib/server/server-rendering";
 export * from "./lib/server/server-types";
 export * from "./lib/server/server-utils";
 export * from "./lib/server/backends/json-sites";
@@ -22,98 +11,3 @@ export * from "./lib/server/backends/redis";
 
 export { createSiteEndpoint } from "./pages/api/sites/[siteName]";
 export { createMetricsEndpoint } from "./pages/api/metrics";
-
-/**
- * Handles details around serving a site in a manner suitable for a full SSR render.
- * The selection is persisted in the server's session store, and a session ID is
- * returned to the user via cookie.
- */
-export async function serverSideRenderedSite(
-  server: InstantBanditServer,
-  siteName: string,
-  req: IncomingMessage & { cookies: NextApiRequestCookies },
-) {
-  await server.init();
-
-  const validatedRequest = await validateUserRequest({
-    allowNoSession: true,
-    allowedOrigins: server.origins,
-    headers: req.headers,
-    siteName,
-    url: req.url,
-  });
-
-  const sid: string | null = null;
-  if (exists(req.cookies[HEADER_SESSION_ID])) {
-    validatedRequest.sid = req.cookies[HEADER_SESSION_ID];
-  }
-
-  const { sessions } = server;
-  let session: SessionDescriptor;
-
-  // First time visitors and robots get a blank session.
-  // The POST to the metrics endpoint when IB mounts will create a real one.
-  if (!exists(sid) || sid === "") {
-    session = makeNewSession(sid ?? "");
-  } else {
-    try {
-      session = await sessions.getOrCreateSession(validatedRequest);
-    } catch (err) {
-      console.log(`[IB] Error fetching session for '${sid}': ${err}`);
-      session = makeNewSession();
-    }
-  }
-
-
-  const { loader, metrics } = DEFAULT_BANDIT_OPTIONS.providers;
-  const ctx = createBanditContext({
-    providers: {
-      loader,
-      metrics,
-
-      //
-      // Here we inject the session from the server's asynchronous session store into
-      // the InstantBandit component's *synchronous* store. This is done for SSR.
-      //
-      // In order to complete the render entirely on the server and avoid client-side
-      // hydration, the component needs to render synchronously in one pass.
-      //
-      session: () => {
-        return {
-          id: session.sid,
-          getOrCreateSession: () => session,
-          hasSeen() {
-            return false;
-          },
-          persistVariant() {
-            // We do this server side below
-            return;
-          },
-          save: () => session,
-        };
-      },
-    },
-  });
-
-  // Call the backend directly for the site and skip an HTTP request
-  const { site: siteConfig } = await server.getSite(validatedRequest);
-  const site = await ctx.init(siteConfig);
-
-  const { experiment, variant } = ctx;
-
-  if (!session) {
-    session = makeNewSession(randomUUID());
-    session.selections[site.name] = {
-      [experiment.id]: [variant.name],
-    };
-  }
-
-  // Skip awaiting to avoid a round-trip to some backend
-  server.sessions.markVariantSeen(session, site, experiment.id, variant.name)
-    .catch(err => console.warn(`[IB]: Error marking variant '${variant.name}' seen: ${err}`));
-
-  return {
-    site,
-    select: variant.name,
-  };
-}

--- a/testing/tests/backends/redis.test.ts
+++ b/testing/tests/backends/redis.test.ts
@@ -5,7 +5,7 @@ import { getRedisBackend } from "../../../lib/server/backends/redis";
 import { DefaultMetrics, DEFAULT_ORIGIN } from "../../../lib/constants";
 import { makeKey, toNumber } from "../../../lib/server/server-utils";
 import { DEFAULT_EXPERIMENT, DEFAULT_SITE, DEFAULT_VARIANT } from "../../../lib/defaults";
-import { exists } from "../../../lib/utils";
+import { exists, makeNewSession } from "../../../lib/utils";
 import { MetricsBatch, MetricsSample } from "../../../lib/models";
 import { randomBytes, randomUUID } from "crypto";
 import { ValidatedRequest } from "../../../lib/server/server-types";
@@ -27,9 +27,8 @@ const TEST_REQ: ValidatedRequest = {
   },
   session: {
     sid: TEST_SESH,
-    site: DEFAULT_SITE.name,
     lastSeen: new Date().getTime(),
-    variants: {}
+    selections: {}
   }
 };
 
@@ -203,6 +202,7 @@ describe("backend", () => {
   function makeBatch(props: Partial<MetricsBatch> = {}, entries: Partial<MetricsSample>[] = []) {
     const def: MetricsBatch = {
       site: DEFAULT_SITE.name,
+      session: makeNewSession(),
       experiment: DEFAULT_EXPERIMENT.name,
       variant: DEFAULT_VARIANT.name,
       entries: [],

--- a/testing/tests/backends/redis.test.ts
+++ b/testing/tests/backends/redis.test.ts
@@ -1,3 +1,4 @@
+import { randomBytes, randomUUID } from "crypto";
 import { Redis } from "ioredis";
 
 import * as constants from "../../../lib/constants";
@@ -7,7 +8,6 @@ import { makeKey, toNumber } from "../../../lib/server/server-utils";
 import { DEFAULT_EXPERIMENT, DEFAULT_SITE, DEFAULT_VARIANT } from "../../../lib/defaults";
 import { exists, makeNewSession } from "../../../lib/utils";
 import { MetricsBatch, MetricsSample } from "../../../lib/models";
-import { randomBytes, randomUUID } from "crypto";
 import { ValidatedRequest } from "../../../lib/server/server-types";
 import { MetricName } from "../../../lib/types";
 

--- a/testing/tests/backends/redis.test.ts
+++ b/testing/tests/backends/redis.test.ts
@@ -202,7 +202,6 @@ describe("backend", () => {
   function makeBatch(props: Partial<MetricsBatch> = {}, entries: Partial<MetricsSample>[] = []) {
     const def: MetricsBatch = {
       site: DEFAULT_SITE.name,
-      session: makeNewSession(),
       experiment: DEFAULT_EXPERIMENT.name,
       variant: DEFAULT_VARIANT.name,
       entries: [],

--- a/testing/tests/server/server.test.ts
+++ b/testing/tests/server/server.test.ts
@@ -8,7 +8,6 @@ import {
 import { buildInstantBanditServer } from "../../../lib/server/server-core";
 import { SessionDescriptor } from "../../../lib/types";
 import { makeNewSession } from "../../../lib/utils";
-import { DEFAULT_SITE } from "../../../lib/defaults";
 
 
 describe("server", () => {

--- a/testing/tests/server/server.test.ts
+++ b/testing/tests/server/server.test.ts
@@ -103,11 +103,7 @@ describe("server", () => {
       async connect() { return; },
       async disconnect() { return; },
       async getOrCreateSession() {
-        return {
-          sid: "",
-          site: DEFAULT_SITE.name,
-          variants: {},
-        };
+        return makeNewSession();
       },
       async markVariantSeen(session: SessionDescriptor) {
         return session;


### PR DESCRIPTION
This PR decouples sessions from sites. Previously, users got a session for any sites on the domain. They now have a singular session per domain. Sessions in Redis are now keyed as `session:<session-UUID>`, and sessions have a "selections" map of experiments -> variants, with the last variant being the most recent.

Also, the metrics endpoint now responds to valid users with their sessions from Redis, which the client takes as the source of truth.