### PR TITLE
Add loading timeout

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -25,6 +25,7 @@ export const PARAM_TIMESTAMP = "ts";
 export const PARAM_SELECT = "select";
 export const HEADER_SESSION_ID = "ibsession";
 
+export const DEFAULT_TIMEOUT = 1000;
 export const PROBABILITY_PRECISION = 4;
 export const UUID_LENGTH = 36;
 export const MAX_STORAGE_KEY_LENGTH = 256;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -12,6 +12,7 @@ export type InstantBanditProps = {
   site?: Site
   debug?: boolean
   options?: InstantBanditOptions
+  timeout?: number
   onReady?: (ctx: InstantBanditContext) => void
   onError?: (err?: Error, ctx?: InstantBanditContext) => void
 };


### PR DESCRIPTION
Adds a timeout to the InstantBandit component. When the IB component times out, the default site is displayed. The timeout can be specified on the component by the `timeout` prop and is in milliseconds. The default is currently set to 1000.