### PR TITLE
Origin check flag more forgiving

### DIFF
--- a/lib/server/server-utils.ts
+++ b/lib/server/server-utils.ts
@@ -110,7 +110,7 @@ export async function getSessionIdFromHeaders(headers: InstantBanditHeaders): Pr
  * @returns 
  */
 export function validateClientReportedOrigin(allowedOrigins: Origins, origin: string | null | undefined): boolean {
-  if (env.IB_ENFORCE_ORIGIN_CHECK === "false") {
+  if (env.IB_ENFORCE_ORIGIN_CHECK !== "true") {
     return true;
   }
 


### PR DESCRIPTION
Makes the origin check flag more forgiving by inverting the boolean check. You must explicitly set the flag "true".