### PR TITLE
Consume text/plain ND-JSON metrics

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,6 @@
       "name": "Attach server",
       "type": "node",
       "request": "attach",
-      "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "skipFiles": [
         "<node_internals>/**"
@@ -35,6 +34,7 @@
       "runtimeArgs": [
         "--inspect-brk=localhost:9230",
         "${workspaceRoot}/node_modules/.bin/jest",
+        "-c=${workspaceRoot}/jest.config.js",
         "--runInBand",
         "--time=648000",
         "-t",
@@ -42,14 +42,12 @@
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9230
     },
     {
       "name": "Launch stack",
       "type": "node-terminal",
       "request": "launch",
       "command": "npm run dev",
-      "console": "integratedTerminal",
       "serverReadyAction": {
         "pattern": "started server on .+, url: (https?://.+)",
         "uriFormat": "%s",

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -30,6 +30,10 @@ export const PROBABILITY_PRECISION = 4;
 export const UUID_LENGTH = 36;
 export const MAX_STORAGE_KEY_LENGTH = 256;
 export const MAX_STORAGE_VALUE_LENGTH = 1024;
+export const METRICS_MAX_LENGTH = 512 * 1024;
+export const METRICS_MAX_ITEM_LENGTH = 1024;
+export const METRICS_PAYLOAD_IGNORED = { error: "ignored" } as const;
+export const METRICS_PAYLOAD_SIZE_ERR = { error: "size" } as const;
 
 /**
  * Metrics tracked by Instant Bandit by default

--- a/lib/providers/metrics.ts
+++ b/lib/providers/metrics.ts
@@ -3,7 +3,7 @@ import { DEFAULT_OPTIONS } from "../defaults";
 import { InstantBanditContext } from "../contexts";
 import { Metric, MetricsProvider, MetricsSinkOptions, SessionDescriptor, TimerLike } from "../types";
 import { MetricsBatch, MetricsSample } from "../models";
-import { env, exists, getCookie } from "../utils";
+import { encodeMetricsBatch, env, exists, getCookie } from "../utils";
 
 
 
@@ -123,9 +123,9 @@ export function getHttpMetricsSink(initOptions?: Partial<MetricsSinkOptions>): M
 // Note: sendBeacon is synchronous (fire and forget), and will return `true` even in the case server error
 export function sendBatchViaBeacon(url: URL, batch: MetricsBatch) {
   const blob = new Blob(
-    [JSON.stringify(batch)],
+    [encodeMetricsBatch(batch)],
     {
-      type: "application/json; charset=UTF-8",
+      type: "application/text; charset=UTF-8",
     }
   );
   return navigator.sendBeacon(url + "", blob);
@@ -137,10 +137,10 @@ export async function sendBatchViaFetch(url: URL, sessionId: string, batch: Metr
     method: "POST",
     headers: {
       "Accept": "application/json",
-      "Content-Type": "application/json",
+      "Content-Type": "text/plain; charset=UTF-8",
       [constants.HEADER_SESSION_ID]: sessionId,
     },
-    body: JSON.stringify(batch),
+    body: encodeMetricsBatch(batch),
   });
 
   const { status, statusText } = resp;

--- a/lib/server/server-internal.ts
+++ b/lib/server/server-internal.ts
@@ -1,6 +1,6 @@
 import env from "./environment";
 import { InstantBanditServer, InstantBanditServerOptions } from "./server-types";
-import { buildInstantBanditServer } from "./server-core";
+import { buildInstantBanditServer, DEFAULT_SERVER_OPTIONS } from "./server-core";
 import { getJsonSiteBackend } from "./backends/json-sites";
 import { getRedisBackend } from "./backends/redis";
 
@@ -9,11 +9,13 @@ const redis = getRedisBackend();
 const json = getJsonSiteBackend();
 
 const DEFAULT_DEV_SERVER_OPTIONS: Partial<InstantBanditServerOptions> = {
-    clientOrigins: (env.IB_ORIGINS_ALLOWLIST ?? env.IB_BASE_API_URL),
-    sessions: redis,
-    metrics: redis,
-    models: json,
-};
+  ...DEFAULT_SERVER_OPTIONS,
+  clientOrigins: (env.IB_ORIGINS_ALLOWLIST ?? env.IB_BASE_API_URL),
+  sessions: redis,
+  metrics: redis,
+  models: json,
+} as const;
+Object.freeze(DEFAULT_DEV_SERVER_OPTIONS);
 
 /**
  * This server helper intended is intended for use by the Instant Bandit repo.

--- a/lib/server/server-types.ts
+++ b/lib/server/server-types.ts
@@ -13,6 +13,9 @@ export type InstantBanditServerOptions = {
   models: ModelsBackend
   sessions: SessionsBackend
   clientOrigins: string | string[]
+  allowMetricsPayloads: boolean
+  maxBatchItemLength: number
+  maxBatchLength: number
 };
 
 /**
@@ -20,6 +23,7 @@ export type InstantBanditServerOptions = {
  * providing configuration, metrics storage, and session handling.
  */
 export type InstantBanditServer = {
+  readonly options: InstantBanditServerOptions
   readonly origins: Origins
   readonly metrics: MetricsBackend
   readonly models: ModelsBackend
@@ -136,4 +140,13 @@ export type ConnectingBackendFunctions<TConnection = unknown> = {
   connected: boolean
   connect(): Promise<TConnection>
   disconnect(): Promise<TConnection>
+};
+
+/**
+ * Options for decoding metrics batches
+ */
+export type MetricsDecodeOptions = {
+  maxBatchLength: number
+  maxBatchItemLength: number
+  allowMetricsPayloads: boolean
 };

--- a/testing/tests/server/server.test.ts
+++ b/testing/tests/server/server.test.ts
@@ -11,14 +11,14 @@ import { makeNewSession } from "../../../lib/utils";
 
 
 describe("server", () => {
-  const TEST_CONFIG: InstantBanditServerOptions = {
+  const TEST_CONFIG: Partial<InstantBanditServerOptions> = {
     clientOrigins: [],
     metrics: getStubMetrics(),
     models: getStubModels(),
     sessions: getStubSessions(),
   };
 
-  let config: InstantBanditServerOptions = TEST_CONFIG;
+  let config = TEST_CONFIG;
   let server = buildInstantBanditServer(config);
 
   beforeEach(async () => {
@@ -36,7 +36,7 @@ describe("server", () => {
       connectedModels = 0, disconnectedModels = 0;
       connectedSessions = 0, disconnectedSessions = 0;
 
-      config = Object.assign(TEST_CONFIG, {
+      config = Object.assign({}, TEST_CONFIG, {
         metrics: {
           async connect() { ++connectedMetrics; },
           async disconnect() { ++disconnectedMetrics; },

--- a/testing/tests/utils.test.ts
+++ b/testing/tests/utils.test.ts
@@ -1,9 +1,149 @@
-import { HEADER_SESSION_ID } from "../../lib/constants";
-import { deepFreeze, exists, getCookie } from "../../lib/utils";
+import { DefaultMetrics, HEADER_SESSION_ID, METRICS_PAYLOAD_IGNORED } from "../../lib/constants";
+import { MetricsBatch, MetricsSample } from "../../lib/models";
+import { MetricsDecodeOptions } from "../../lib/server/server-types";
+import { decodeMetricsBatch } from "../../lib/server/server-utils";
+import { deepFreeze, encodeMetricsBatch, exists, getCookie } from "../../lib/utils";
 
 
 describe("utils", () => {
-  describe("defined", () => {
+  describe("encode/decode metrics", () => {
+    const entries: MetricsSample[] = [
+      { ts: 0, name: DefaultMetrics.EXPOSURES },
+      { ts: 1, name: DefaultMetrics.CONVERSIONS },
+      { ts: 2, name: DefaultMetrics.EXPOSURES },
+    ];
+
+    const entriesWithPayloads: MetricsSample[] = [
+      { ts: 0, name: "evt.with-no-payload" },
+      { ts: 1, name: "evt.with-number", payload: 5 },
+      { ts: 2, name: "evt.with-object", payload: { cls: 0.0, lcp: 1, ttfb: 100 } },
+      { ts: 3, name: "evt.with-string", payload: "hello" },
+      { ts: 4, name: "evt.with-string-escaped-newline", payload: `escaped\nnewline` },
+      {
+        ts: 5, name: "evt.with-string-natural-newline", payload: `natural 
+      newline`
+      },
+      { ts: 6, name: "evt.with-just-newline", payload: `\n` },
+    ];
+
+    const batch: MetricsBatch = {
+      site: "SITE",
+      experiment: "EXP",
+      variant: "VAR",
+      entries: [],
+    };
+
+    const batchWithSamples = {
+      ...batch,
+      entries,
+    };
+
+    const batchWithSamplesBearingPayloads = {
+      ...batch,
+      entries: entriesWithPayloads,
+    };
+
+    const decodeOptions: MetricsDecodeOptions = {
+      allowMetricsPayloads: true,
+      maxBatchItemLength: 1024,
+      maxBatchLength: 10 * 1024,
+    };
+
+    const expectedHeader = `{"site":"SITE","experiment":"EXP","variant":"VAR"}`;
+
+    describe(encodeMetricsBatch, () => {
+      it("encodes a batch header", () => {
+        const encoded = encodeMetricsBatch(batch);
+        expect(encoded).toBe(expectedHeader);
+      });
+
+      it("encodes lines without payloads", () => {
+        const encoded = encodeMetricsBatch(batchWithSamples);
+        const lines = encoded.split("\n");
+        const [header, line1, line2, line3] = lines;
+        expect(lines.length).toBe(1 + entries.length);
+        expect(header).toBe(expectedHeader);
+        expect(line1).toBe(`{"ts":0,"name":"exposures"}`);
+        expect(line2).toBe(`{"ts":1,"name":"conversions"}`);
+        expect(line3).toBe(`{"ts":2,"name":"exposures"}`);
+      });
+
+      it("encodes lines with payloads", () => {
+        const encoded = encodeMetricsBatch(batchWithSamplesBearingPayloads);
+        const lines = encoded.split("\n");
+        expect(lines.length).toBe(14);
+        expect(lines[0]).toBe(expectedHeader);
+        expect(lines[1]).toBe(`{"ts":0,"name":"evt.with-no-payload"}`);
+        expect(lines[2]).toBe(`{"ts":1,"name":"evt.with-number","payload":1}`);
+        expect(lines[3]).toBe(`5`);
+        expect(lines[4]).toBe(`{"ts":2,"name":"evt.with-object","payload":1}`);
+        expect(lines[5]).toBe(`{"cls":0,"lcp":1,"ttfb":100}`);
+        expect(lines[6]).toBe(`{"ts":3,"name":"evt.with-string","payload":1}`);
+        expect(lines[7]).toBe(`"hello"`);
+        expect(lines[8]).toBe(`{"ts":4,"name":"evt.with-string-escaped-newline","payload":1}`);
+        expect(lines[9]).toBe(`"escaped\\nnewline"`);
+        expect(lines[10]).toBe(`{"ts":5,"name":"evt.with-string-natural-newline","payload":1}`);
+        expect(lines[11]).toBe(`"natural \\n      newline"`);
+        expect(lines[12]).toBe(`{"ts":6,"name":"evt.with-just-newline","payload":1}`);
+        expect(lines[13]).toBe(`"\\n"`);
+      });
+    });
+
+    describe(decodeMetricsBatch, () => {
+      it("throws on unknown keys", () => {
+        expect(() => decodeMetricsBatch(`{"site":"SITE","experiment":"EXP","variant":"VAR", foo: "baz"}`
+          , decodeOptions)).toThrow();
+      });
+
+      it("throws if the batch contents are too long", () => {
+        const encoded = encodeMetricsBatch(batchWithSamplesBearingPayloads);
+        expect(() => decodeMetricsBatch(encoded, {
+          ...decodeOptions,
+          maxBatchLength: 32,
+        })).toThrow();
+      });
+
+      it("throws if a batch item is too long", () => {
+        const encoded = encodeMetricsBatch(batchWithSamplesBearingPayloads);
+        expect(() => decodeMetricsBatch(encoded, {
+          ...decodeOptions,
+          maxBatchItemLength: 8,
+        })).toThrow();
+      });
+
+      it("ignores payloads when allow payloads flag is false", () => {
+        const encoded = encodeMetricsBatch(batchWithSamplesBearingPayloads);
+        const decoded = decodeMetricsBatch(encoded, {
+          ...decodeOptions,
+          allowMetricsPayloads: false,
+        });
+
+        // Skip the first item (no payload)
+        decoded.entries.slice(1).forEach(e =>
+          expect(e.payload).toStrictEqual(METRICS_PAYLOAD_IGNORED));
+      });
+
+      it("decodes a batch header", () => {
+        const encoded = encodeMetricsBatch(batchWithSamples);
+        const decoded = decodeMetricsBatch(encoded, decodeOptions);
+        expect(decoded).toStrictEqual(batchWithSamples);
+      });
+
+      it("decodes lines without payloads", () => {
+        const encoded = encodeMetricsBatch(batchWithSamples);
+        const decoded = decodeMetricsBatch(encoded, decodeOptions);
+        expect(decoded).toStrictEqual(batchWithSamples);
+      });
+
+      it("decodes lines with payloads", () => {
+        const encoded = encodeMetricsBatch(batchWithSamplesBearingPayloads);
+        const decoded = decodeMetricsBatch(encoded, decodeOptions);
+        expect(decoded).toStrictEqual(batchWithSamplesBearingPayloads);
+      });
+    });
+  });
+
+  describe(exists, () => {
     it("returns false for null", () => expect(exists(null)).toStrictEqual(false));
     it("returns false for undefined", () => expect(exists(undefined)).toStrictEqual(false));
     it("returns true for an empty string", () => expect(exists("")).toStrictEqual(true));
@@ -11,7 +151,7 @@ describe("utils", () => {
     it("returns true for NaN", async () => expect(exists(0)).toStrictEqual(true));
   });
 
-  describe("deepFreeze", () => {
+  describe(deepFreeze, () => {
     let obj: { a: { b: { c } } };
     beforeEach(() => obj = { a: { b: { c: {} } } });
 
@@ -31,7 +171,7 @@ describe("utils", () => {
     });
   });
 
-  describe("getCookie", () => {
+  describe(getCookie, () => {
     const nullUuid = "00000000-0000-0000-0000-000000000000";
     const cookieStr = "   cookie-1=foo;cookie-2=baz      ;cookie-3=bar;;;";
     const multipleCookies = "foo=1;foo=2;foo=3";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,9 +28,10 @@
     "**/*.tsx"
   ],
   "exclude": [
-    "**/dist",
-    "**/node_modules",
+    "dist/**",
+    "node_modules/**",
     "server.ts",
+    "server.d.ts",
     "index.ts",
   ]
 }


### PR DESCRIPTION
This PR tightens up metrics ingestion to be more strict:
- Metrics batches are now encoded as ND-JSON and transmitted with the MIME-type `text/plain`
- This allows for finer grained control over size limits and what we parse
- Default max length for individual metrics samples is 1K, 512K per batch by default
- Custom payloads on metrics events, e.g. web vitals, custom event data, etc, are now not accepted by default
- This is controlled by the `allowMetricsPayloads` flag on `InstantBanditServerOptions`, default `false`
- When metrics payloads are disabled, any present are skipped but the parent messages are kept
- Skipped payloads are replaced by an object indicating a payload was received, but not ingested