### PR TITLE
request cookie type def changes

### DIFF
--- a/lib/server/server-rendering.ts
+++ b/lib/server/server-rendering.ts
@@ -14,7 +14,7 @@ import { validateUserRequest } from "./server-utils";
 export async function serverSideRenderedSite(
   server: InstantBanditServer,
   siteName: string,
-  req: IncomingMessage & { cookies: { [key: string]: string } },
+  req: IncomingMessage & {cookies: Partial<{[key: string]: string}>},
 ) {
   await server.init();
 


### PR DESCRIPTION
Nextjs has updated it's type defs for GetServerSidePropsContext to allow Partial<> on cookies.
Seems reasonable to update our type def to match.
Relevant commit on NextJs: https://github.com/vercel/next.js/commit/305214476b894bbf04a047e33e163ac79c94f6fe
 
<img width="1507" alt="Screen Shot 2022-07-13 at 12 47 24 PM" src="https://user-images.githubusercontent.com/22460757/178818906-40ee19c1-bd9d-4c68-8198-0ac808f3482d.png">
